### PR TITLE
Remove masks and gradients in default dialogs

### DIFF
--- a/resources/kpay/kpay.gui
+++ b/resources/kpay/kpay.gui
@@ -43,30 +43,16 @@
       <rect class="full-size" fill="fb-black" opacity="0.8" />
       
       <textarea id="kpay_trialEndedMessage" x="5%" y="18%" width="90%" font-size="26" font-family="System-Regular" fill="#ffffff" text-anchor="middle" text-length="128"></textarea>
-      <mask id="kPay_TrialEndedCodeMask">
-        <text x="50%" y="100%-25" width="100%" id="kpay_trialEndedCode" text-anchor="middle" font-size="67" fill="#ffffff" font-family="System-Bold">00000</text>
-      </mask>
-      <svg mask="#kPay_TrialEndedCodeMask" width="100%" height="100%">
-        <gradientRect x="0" width="100%" height="100%"
-          gradient-type="linear"
-          gradient-x1="0" gradient-y1="60%"
-          gradient-x2="0" gradient-y2="90%"
-          gradient-color1="#ffffff" gradient-color2="#8b8b8b" />
+      <svg id="kPay_TrialEndedCodeMask" width="100%" height="100%">
+        <text x="50%" y="100%-25" width="100%" id="kpay_trialEndedCode" text-anchor="middle" font-size="67" fill="#8b8b8b" font-family="System-Bold">00000</text>
       </svg>
     </svg>
  
     <svg x="0" y="0" width="100%" height="100%" id="kpay_purchaseSuccessDialog" display="none">
       <rect class="full-size" fill="fb-black" opacity="0.8" />
         
-      <mask id="kPay_PurchaseSuccessCircleMask">
-        <arc x="50%-73" y="23" width="146" height="146" arc-width="3" start-angle="0" sweep-angle="360" />
-      </mask>
-      <svg mask="#kPay_PurchaseSuccessCircleMask" width="100%" height="100%">
-        <gradientRect width="100%" height="100%"
-          gradient-type="linear"
-          gradient-x1="0" gradient-y1="23"
-          gradient-x2="0" gradient-y2="169"
-          gradient-color1="#3cba92" gradient-color2="#0ba360" />
+      <svg id="kPay_PurchaseSuccessCircleMask" width="100%" height="100%">
+        <arc fill="#3cba92" x="50%-73" y="23" width="146" height="146" arc-width="3" start-angle="0" sweep-angle="360" />
       </svg>
       <image x="50%-41" y="67" width="82" height="64" href="kpay/kpay_check.png" />
       <text x="50%" y="100%-40" text-anchor="middle" width="100%" font-size="30" font-family="System-Regular" fill="#ffffff">Purchase Successful!</text>


### PR DESCRIPTION
Removed masks and gradients in default dialogs because of display problems in scalable watch face. 
Visually not a big difference on device screen. 
Also saves a litte memory. Example from KPay project before and after the change: (average: 40500/65528) -> (average: 40261/65528)